### PR TITLE
Use find_program results for llvm-cov and llvm-profdata

### DIFF
--- a/code-coverage.cmake
+++ b/code-coverage.cmake
@@ -81,6 +81,7 @@ option(
 
 # Programs
 find_program(LLVM_COV_PATH llvm-cov)
+find_program(LLVM_PROFDATA_PATH llvm-profdata)
 find_program(LCOV_PATH lcov)
 find_program(GENHTML_PATH genhtml)
 
@@ -234,7 +235,7 @@ function(target_code_coverage TARGET_NAME)
           DEPENDS ccov-preprocessing ${TARGET_NAME})
 
         add_custom_target(ccov-processing-${TARGET_NAME}
-                          COMMAND llvm-profdata merge -sparse
+                          COMMAND ${LLVM_PROFDATA_PATH} merge -sparse
                                   ${TARGET_NAME}.profraw -o
                                   ${TARGET_NAME}.profdata
                           DEPENDS ccov-run-${TARGET_NAME})
@@ -247,20 +248,20 @@ function(target_code_coverage TARGET_NAME)
         endif()
 
         add_custom_target(ccov-show-${TARGET_NAME}
-                          COMMAND llvm-cov show $<TARGET_FILE:${TARGET_NAME}>
+                          COMMAND ${LLVM_COV_PATH} show $<TARGET_FILE:${TARGET_NAME}>
                                   -instr-profile=${TARGET_NAME}.profdata
                                   -show-line-counts-or-regions ${EXCLUDE_REGEX}
                           DEPENDS ccov-processing-${TARGET_NAME})
 
         add_custom_target(ccov-report-${TARGET_NAME}
-                          COMMAND llvm-cov report $<TARGET_FILE:${TARGET_NAME}>
+                          COMMAND ${LLVM_COV_PATH} report $<TARGET_FILE:${TARGET_NAME}>
                                   -instr-profile=${TARGET_NAME}.profdata
                                   ${EXCLUDE_REGEX}
                           DEPENDS ccov-processing-${TARGET_NAME})
 
         add_custom_target(
           ccov-${TARGET_NAME}
-          COMMAND llvm-cov show $<TARGET_FILE:${TARGET_NAME}>
+          COMMAND ${LLVM_COV_PATH} show $<TARGET_FILE:${TARGET_NAME}>
                   -instr-profile=${TARGET_NAME}.profdata
                   -show-line-counts-or-regions
                   -output-dir=${CMAKE_COVERAGE_OUTPUT_DIRECTORY}/${TARGET_NAME}
@@ -384,7 +385,7 @@ function(add_code_coverage_all_targets)
       # Targets
       add_custom_target(
         ccov-all-processing
-        COMMAND llvm-profdata merge -o
+        COMMAND ${LLVM_PROFDATA_PATH} merge -o
                 ${CMAKE_COVERAGE_OUTPUT_DIRECTORY}/all-merged.profdata -sparse
                 `cat ${CMAKE_COVERAGE_OUTPUT_DIRECTORY}/profraw.list`)
 
@@ -398,7 +399,7 @@ function(add_code_coverage_all_targets)
       add_custom_target(
         ccov-all-report
         COMMAND
-          llvm-cov report `cat ${CMAKE_COVERAGE_OUTPUT_DIRECTORY}/binaries.list`
+          ${LLVM_COV_PATH} report `cat ${CMAKE_COVERAGE_OUTPUT_DIRECTORY}/binaries.list`
           -instr-profile=${CMAKE_COVERAGE_OUTPUT_DIRECTORY}/all-merged.profdata
           ${EXCLUDE_REGEX}
         DEPENDS ccov-all-processing)
@@ -406,7 +407,7 @@ function(add_code_coverage_all_targets)
       add_custom_target(
         ccov-all
         COMMAND
-          llvm-cov show `cat ${CMAKE_COVERAGE_OUTPUT_DIRECTORY}/binaries.list`
+          ${LLVM_COV_PATH} show `cat ${CMAKE_COVERAGE_OUTPUT_DIRECTORY}/binaries.list`
           -instr-profile=${CMAKE_COVERAGE_OUTPUT_DIRECTORY}/all-merged.profdata
           -show-line-counts-or-regions
           -output-dir=${CMAKE_COVERAGE_OUTPUT_DIRECTORY}/all-merged


### PR DESCRIPTION
Add find_program() call for llvm-profdata, and use the results of
find_program() for llvm-cov instead of searching the PATH every
invocation.