### PR TITLE
Fix exclude parameter expansion in ccov-all-processing

### DIFF
--- a/code-coverage.cmake
+++ b/code-coverage.cmake
@@ -488,7 +488,7 @@ function(add_code_coverage_all_targets)
       if(LLVM_COV_VERSION VERSION_GREATER_EQUAL "7.0.0")
         foreach(EXCLUDE_ITEM ${add_code_coverage_all_targets_EXCLUDE})
           set(EXCLUDE_REGEX ${EXCLUDE_REGEX}
-                            -ignore-filename-regex=${EXCLUDE_ITEM})
+                            -ignore-filename-regex='${EXCLUDE_ITEM}')
         endforeach()
       endif()
 

--- a/code-coverage.cmake
+++ b/code-coverage.cmake
@@ -504,6 +504,19 @@ function(add_code_coverage_all_targets)
           ${EXCLUDE_REGEX}
         DEPENDS ccov-all-processing)
 
+      # Export coverage information so continuous integration tools (e.g. Jenkins) can consume it
+      add_custom_target(
+        ccov-all-export
+        COMMAND
+          ${LLVM_COV_PATH}
+          export
+          `cat
+          ${CMAKE_COVERAGE_OUTPUT_DIRECTORY}/binaries.list`
+          -instr-profile=${CMAKE_COVERAGE_OUTPUT_DIRECTORY}/all-merged.profdata
+          -format="text"
+          ${EXCLUDE_REGEX} > ${CMAKE_COVERAGE_OUTPUT_DIRECTORY}/coverage.json
+        DEPENDS ccov-all-processing)
+
         # Generate HTML output of all added targets for perusal
       add_custom_target(
         ccov-all


### PR DESCRIPTION
Regexp containing * doesn't work without this change. E.g.:

find_package(Boost COMPONENTS unit_test_framework REQUIRED)
add_code_coverage_all_targets(EXCLUDE ${Boost_INCLUDE_DIRS}/*)