### PR TITLE
Setting ininial value for FORMAT_FILES variable

### DIFF
--- a/formatting.cmake
+++ b/formatting.cmake
@@ -39,7 +39,8 @@ endif()
 # ~~~
 function(clang_format TARGET_NAME)
   if(CLANG_FORMAT_EXE)
-    # Check through the ARGN's, determine existant files
+    set(FORMAT_FILES)
+    # Check through the ARGN's, determine existent files
     foreach(item IN LISTS ARGN)
       if(TARGET ${item})
         # If the item is a target, then we'll attempt to grab the associated
@@ -109,6 +110,7 @@ endif()
 # ~~~
 function(cmake_format TARGET_NAME)
   if(CMAKE_FORMAT_EXE)
+    set(FORMAT_FILES)
     # Determine files that exist
     foreach(iter IN LISTS ARGN)
       if(EXISTS ${iter})


### PR DESCRIPTION
This patch aims to fix CMake warnings like these:
```
CMake Warning (dev) at external/cmake-scripts/formatting.cmake:113 (set):
  uninitialized variable 'FORMAT_FILES'
Call Stack (most recent call first):
  CMakeLists.txt:100 (cmake_format)
This warning is for project developers.  Use -Wno-dev to suppress it.
```