### PR TITLE
Setting ininial value for EXCLUDE_REGEX variable

### DIFF
--- a/code-coverage.cmake
+++ b/code-coverage.cmake
@@ -494,6 +494,7 @@ function(add_code_coverage_all_targets)
       add_custom_target(ccov-all-processing COMMAND ;)
 
       # Exclusion regex string creation
+      set(EXCLUDE_REGEX)
       foreach(EXCLUDE_ITEM ${add_code_coverage_all_targets_EXCLUDE})
         set(EXCLUDE_REGEX ${EXCLUDE_REGEX} --remove ${COVERAGE_INFO}
                           '${EXCLUDE_ITEM}')


### PR DESCRIPTION
This patch aims to fix CMake warnings like these:
```
CMake Warning (dev) at external/cmake-scripts/code-coverage.cmake:498 (set):
  uninitialized variable 'EXCLUDE_REGEX'
Call Stack (most recent call first):
  CMakeLists.txt:157 (add_code_coverage_all_targets)
This warning is for project developers.  Use -Wno-dev to suppress it.
```