### PR TITLE
Add hook to create ccov target each time that add_ex.. and add_lib...…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is a collection of quite useful scripts that expand the possibilities for b
       - [1b - Via target commands](#1b---via-target-commands)
     - [Example 2: Target instrumented, but with regex pattern of files to be excluded from report](#example-2-target-instrumented-but-with-regex-pattern-of-files-to-be-excluded-from-report)
     - [Example 3: Target added to the 'ccov' and 'ccov-all' targets](#example-3-target-added-to-the-ccov-and-ccov-all-targets)
+    - [Example 4: Hook all targets](#example-4-hook-all-targets)
 - [AFL Fuzzing Instrumentation `afl-fuzzing.cmake`](#afl-fuzzing-instrumentation-afl-fuzzingcmake)
   - [Usage](#usage-1)
 - [Compiler Options `compiler-options.cmake`](#compiler-options-compiler-optionscmake)
@@ -136,6 +137,7 @@ To enable any code coverage instrumentation/targets, the single CMake option of 
 From this point, there are two primary methods for adding instrumentation to targets:
 1. A blanket instrumentation by calling `add_code_coverage()`, where all targets in that directory and all subdirectories are automatically instrumented.
 2. Per-target instrumentation by calling `target_code_coverage(<TARGET_NAME>)`, where the target is given and thus only that target is instrumented. This applies to both libraries and executables.
+3. Automatically add coverage for each target with `-DCCOV_TARGETS_HOOK=On` and `-DCCOV_TARGETS_HOOK_ARGS=...` for default values, requires `add_code_coverage()` or similar.
 
 To add coverage targets, such as calling `make ccov` to generate the actual coverage information for perusal or consumption, call `target_code_coverage(<TARGET_NAME>)` on an *executable* target.
 
@@ -182,6 +184,20 @@ add_code_coverage_all_targets(EXCLUDE test/*) # Adds the 'ccov-all' target set a
 
 add_executable(theExe main.cpp non_covered.cpp)
 target_code_coverage(theExe AUTO ALL EXCLUDE non_covered.cpp test/*) # As an executable target, adds to the 'ccov' and ccov-all' targets, and the reports will exclude the non-covered.cpp file, and any files in a test/ folder.
+```
+
+#### Example 4: Hook all targets
+```
+# this could be as well command line argument
+set(CCOV_TARGETS_HOOK ON) # enable 'add_executable' and 'add_library' hooks
+set(CCOV_TARGETS_HOOK_ARGS ALL AUTO) # set default arguments for coverage
+
+add_code_coverage() # Adds instrumentation to all targets
+
+add_library(theLib lib.cpp) # ccov-theLib target will be add
+
+add_executable(theExe main.cpp) # ccov-theExe target will be add
+target_link_libraries(theExe PRIVATE theLib)
 ```
 
 ## AFL Fuzzing Instrumentation [`afl-fuzzing.cmake`](afl-fuzzing.cmake)

--- a/code-coverage.cmake
+++ b/code-coverage.cmake
@@ -72,12 +72,35 @@
 # add_executable(theExe main.cpp non_covered.cpp)
 # target_code_coverage(theExe AUTO ALL EXCLUDE non_covered.cpp test/*) # As an executable target, adds to the 'ccov' and ccov-all' targets, and the reports will exclude the non-covered.cpp file, and any files in a test/ folder.
 # ~~~
+#
+# Example 4: Hook all targets
+#
+# ~~~
+# set(CCOV_TARGETS_HOOK ON) # enable 'add_executable' and 'add_library' hooks
+# set(CCOV_TARGETS_HOOK_ARGS ALL AUTO) # set default arguments for coverage
+#
+# add_code_coverage() # Adds instrumentation to all targets
+#
+# add_library(theLib lib.cpp) # ccov-theLib target will be add
+#
+# add_executable(theExe main.cpp) # ccov-theExe target will be add
+# target_link_libraries(theExe PRIVATE theLib)
+# ~~~
 
 # Options
 option(
   CODE_COVERAGE
   "Builds targets with code coverage instrumentation. (Requires GCC or Clang)"
   OFF)
+
+option(
+  CCOV_TARGETS_HOOK
+  "Autocapture all new targets."
+  OFF)
+
+option(
+  CCOV_TARGETS_HOOK_ARGS
+  "Default arguments for all hooked targets.")
 
 # Programs
 find_program(LLVM_COV_PATH llvm-cov)
@@ -181,6 +204,25 @@ if(CODE_COVERAGE AND NOT CODE_COVERAGE_ADDED)
   else()
     message(FATAL_ERROR "Code coverage requires Clang or GCC. Aborting.")
   endif()
+
+  if (CCOV_TARGETS_HOOK)
+    if (COMMAND _add_executable)
+      message(FATAL_ERROR "add_executable was already redefined. Only one redefinitions is allowed.")
+    endif()
+    macro(add_executable)
+      _add_executable(${ARGV})
+      target_code_coverage(${ARGV0} ${CCOV_TARGETS_HOOK_ARGS})
+    endmacro(add_executable)
+
+    if (COMMAND _add_library)
+      message(FATAL_ERROR "add_library was already redefined. Only one redefinitions is allowed.")
+    endif()
+    macro(add_library)
+      _add_library(${ARGV})
+      target_code_coverage(${ARGV0} ${CCOV_TARGETS_HOOK_ARGS})
+    endmacro(add_library)
+  endif (CCOV_TARGETS_HOOK)
+
 endif()
 
 # Adds code coverage instrumentation to a library, or instrumentation/targets

--- a/example/code-coverage-hook/CMakeLists.txt
+++ b/example/code-coverage-hook/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.10)
+project(code-coverage-hook C CXX)
+
+# Set the searching location for cmake 'include' locations
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../..;")
+# Include the code coverage module
+cmake_policy(SET CMP0077 NEW)
+
+set(CCOV_TARGETS_HOOK ON)
+set(CCOV_TARGETS_HOOK_ARGS "ALL")
+
+include(code-coverage)
+
+# Require C++11
+include(c++-standards)
+cxx_11()
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+# This introduces the 'ccov-all' targets Also excludes the main file via a regex
+add_code_coverage_all_targets(EXCLUDE coverage.main.cpp)
+
+# The library
+add_library(lib ../src/coverage.cpp)
+
+# The executable
+add_executable(main ../src/coverage.main.cpp)
+target_link_libraries(main PUBLIC lib)
+
+# The second executable
+add_executable(main2 ../src/coverage.main.cpp)
+target_link_libraries(main2 PUBLIC lib)


### PR DESCRIPTION
… is called.

The main motivation for this change was laziness. If I need coverage for each and every target in my project I do not want to double every add_* function with extra to add coverage, I want cmake to do it for me.