### PR TITLE
Add plain option for target coverage

### DIFF
--- a/code-coverage.cmake
+++ b/code-coverage.cmake
@@ -208,6 +208,7 @@ endif()
 # Optional:
 # PUBLIC - Sets the visibility for added compile options to targets to PUBLIC instead of the default of PRIVATE.
 # INTERFACE - Sets the visibility for added compile options to targets to INTERFACE instead of the default of PRIVATE.
+# PLAIN - Do not set any target visibility (backward compatibility with old cmake projects)
 # AUTO - Adds the target to the 'ccov' target so that it can be run in a batch with others easily. Effective on executable targets.
 # ALL - Adds the target to the 'ccov-all' and 'ccov-all-report' targets, which merge several executable targets coverage data to a single report. Effective on executable targets.
 # EXTERNAL - For GCC's lcov, allows the profiling of 'external' files from the processing directory
@@ -218,7 +219,7 @@ endif()
 # ~~~
 function(target_code_coverage TARGET_NAME)
   # Argument parsing
-  set(options AUTO ALL EXTERNAL PUBLIC INTERFACE)
+  set(options AUTO ALL EXTERNAL PUBLIC INTERFACE PLAIN)
   set(single_value_keywords COVERAGE_TARGET_NAME)
   set(multi_value_keywords EXCLUDE OBJECTS ARGS)
   cmake_parse_arguments(
@@ -229,10 +230,16 @@ function(target_code_coverage TARGET_NAME)
   # PRIVATE.
   if(target_code_coverage_PUBLIC)
     set(TARGET_VISIBILITY PUBLIC)
+    set(TARGET_LINK_VISIBILITY PUBLIC)
   elseif(target_code_coverage_INTERFACE)
     set(TARGET_VISIBILITY INTERFACE)
+    set(TARGET_LINK_VISIBILITY INTERFACE)
+  elseif(target_code_coverage_PLAIN)
+    set(TARGET_VISIBILITY PUBLIC)
+    set(TARGET_LINK_VISIBILITY)
   else()
     set(TARGET_VISIBILITY PRIVATE)
+    set(TARGET_LINK_VISIBILITY PRIVATE)
   endif()
 
   if(NOT target_code_coverage_COVERAGE_TARGET_NAME)
@@ -253,7 +260,7 @@ function(target_code_coverage TARGET_NAME)
                                                 "GNU")
       target_compile_options(${TARGET_NAME} ${TARGET_VISIBILITY} -fprofile-arcs
                              -ftest-coverage)
-      target_link_libraries(${TARGET_NAME} ${TARGET_VISIBILITY} gcov)
+      target_link_libraries(${TARGET_NAME} ${TARGET_LINK_VISIBILITY} gcov)
     endif()
 
     # Targets


### PR DESCRIPTION
When no visibility is specified for target, adding coverage with any of the two options: `PUBLIC`  or `INTERFACE` (`PRIVATE` is default) results in error:

    The plain signature for target_link_libraries has already been used with
    the target "xxxxx".  All uses of target_link_libraries with a
    target must be either all-keyword or all-plain.

where
```cmake
target_link_libraries(xxxxx libA libB) # no visibility specified
```

I added `PLAIN` option which do not add any visibility, as the default option is always `PRIVATE`.

Alternatively, one should add `PRIVATE` option and leave no option equivalent to `PLAIN` but this will break back-compatibility, which might not be an issue perhaps. Actually this is what I would prefer Makes it more consistent.