### PR TITLE
Add basic workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,73 @@
+# This is a basic workflow to help you get started with Actions
+name: Code coverage (All example)
+
+# Controls when the action will run. Triggers the workflow on push
+on:
+  push:
+  pull_request:
+  release:
+    # tags:
+    # - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    name: "OS: ${{ matrix.os-version }}  CXX: ${{ matrix.compiler }}"
+    runs-on: ${{ matrix.os-version }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os-version: [ ubuntu-latest ]
+        compiler: [ gcc, clang ]
+        build_type: [ Debug ]
+
+    steps:
+      - name: Print env
+        run: |
+          echo github.event.action: ${{ github.event.action }}
+          echo github.event_name: ${{ github.event_name }}
+
+      - name: Install common dependencies -- gcc
+        if: ${{ matrix.os-version == 'ubuntu-latest' && matrix.compiler == 'gcc' }}
+        run: |
+          sudo apt update
+          sudo apt install lcov -y
+
+      - name: Install common dependencies -- clang
+        if: ${{ matrix.os-version == 'ubuntu-latest' && matrix.compiler == 'clang' }}
+        run: |
+          sudo apt update
+          sudo apt install llvm -y
+
+      - name: Install compiler
+        id: install_cc
+        uses: rlalik/setup-cpp-compiler@v1.1
+        with:
+          compiler: ${{ matrix.compiler }}
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          submodules: recursive
+
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v1.9
+
+      - name: Coverage tests
+        shell: bash
+        env:
+          CC: ${{ steps.install_cc.outputs.cc }}
+          CXX: ${{ steps.install_cc.outputs.cxx }}
+        run: |
+          cmake \
+            -S example/all \
+            -B build_ccov \
+            -DCODE_COVERAGE=ON \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          cmake --build build_ccov --config ${{ matrix.build_type }}
+          cmake --build build_ccov --target help
+          cmake --build build_ccov --target ccov-all

--- a/.github/workflows/coveragea-all.yml
+++ b/.github/workflows/coveragea-all.yml
@@ -1,0 +1,73 @@
+# This is a basic workflow to help you get started with Actions
+name: Code coverage ALL
+
+# Controls when the action will run. Triggers the workflow on push
+on:
+  push:
+  pull_request:
+  release:
+    # tags:
+    # - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    name: "OS: ${{ matrix.os-version }}  CXX: ${{ matrix.compiler }}"
+    runs-on: ${{ matrix.os-version }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os-version: [ ubuntu-latest ]
+        compiler: [ gcc, clang ]
+        build_type: [ Debug ]
+
+    steps:
+      - name: Print env
+        run: |
+          echo github.event.action: ${{ github.event.action }}
+          echo github.event_name: ${{ github.event_name }}
+
+      - name: Install common dependencies -- gcc
+        if: ${{ matrix.os-version == 'ubuntu-latest' && matrix.compiler == 'gcc' }}
+        run: |
+          sudo apt update
+          sudo apt install lcov -y
+
+      - name: Install common dependencies -- clang
+        if: ${{ matrix.os-version == 'ubuntu-latest' && matrix.compiler == 'clang' }}
+        run: |
+          sudo apt update
+          sudo apt install llvm -y
+
+      - name: Install compiler
+        id: install_cc
+        uses: rlalik/setup-cpp-compiler@v1.1
+        with:
+          compiler: ${{ matrix.compiler }}
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          submodules: recursive
+
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v1.9
+
+      - name: Coverage tests
+        shell: bash
+        env:
+          CC: ${{ steps.install_cc.outputs.cc }}
+          CXX: ${{ steps.install_cc.outputs.cxx }}
+        run: |
+          cmake \
+            -S example/code-coverage-all \
+            -B build_ccov \
+            -DCODE_COVERAGE=ON \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          cmake --build build_ccov --config ${{ matrix.build_type }}
+          cmake --build build_ccov --target help
+          cmake --build build_ccov --target ccov-all

--- a/.github/workflows/coveragea-public.yml
+++ b/.github/workflows/coveragea-public.yml
@@ -1,0 +1,73 @@
+# This is a basic workflow to help you get started with Actions
+name: Code coverage PUBLIC
+
+# Controls when the action will run. Triggers the workflow on push
+on:
+  push:
+  pull_request:
+  release:
+    # tags:
+    # - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    name: "OS: ${{ matrix.os-version }}  CXX: ${{ matrix.compiler }}"
+    runs-on: ${{ matrix.os-version }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os-version: [ ubuntu-latest ]
+        compiler: [ gcc, clang ]
+        build_type: [ Debug ]
+
+    steps:
+      - name: Print env
+        run: |
+          echo github.event.action: ${{ github.event.action }}
+          echo github.event_name: ${{ github.event_name }}
+
+      - name: Install common dependencies -- gcc
+        if: ${{ matrix.os-version == 'ubuntu-latest' && matrix.compiler == 'gcc' }}
+        run: |
+          sudo apt update
+          sudo apt install lcov -y
+
+      - name: Install common dependencies -- clang
+        if: ${{ matrix.os-version == 'ubuntu-latest' && matrix.compiler == 'clang' }}
+        run: |
+          sudo apt update
+          sudo apt install llvm -y
+
+      - name: Install compiler
+        id: install_cc
+        uses: rlalik/setup-cpp-compiler@v1.1
+        with:
+          compiler: ${{ matrix.compiler }}
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          submodules: recursive
+
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v1.9
+
+      - name: Coverage tests
+        shell: bash
+        env:
+          CC: ${{ steps.install_cc.outputs.cc }}
+          CXX: ${{ steps.install_cc.outputs.cxx }}
+        run: |
+          cmake \
+            -S example/code-coverage-public \
+            -B build_ccov \
+            -DCODE_COVERAGE=ON \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          cmake --build build_ccov --config ${{ matrix.build_type }}
+          cmake --build build_ccov --target help
+          cmake --build build_ccov --target ccov-preprocessing

--- a/.github/workflows/coveragea-target.yml
+++ b/.github/workflows/coveragea-target.yml
@@ -1,0 +1,73 @@
+# This is a basic workflow to help you get started with Actions
+name: Code coverage TARGET
+
+# Controls when the action will run. Triggers the workflow on push
+on:
+  push:
+  pull_request:
+  release:
+    # tags:
+    # - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    name: "OS: ${{ matrix.os-version }}  CXX: ${{ matrix.compiler }}"
+    runs-on: ${{ matrix.os-version }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os-version: [ ubuntu-latest ]
+        compiler: [ gcc, clang ]
+        build_type: [ Debug ]
+
+    steps:
+      - name: Print env
+        run: |
+          echo github.event.action: ${{ github.event.action }}
+          echo github.event_name: ${{ github.event_name }}
+
+      - name: Install common dependencies -- gcc
+        if: ${{ matrix.os-version == 'ubuntu-latest' && matrix.compiler == 'gcc' }}
+        run: |
+          sudo apt update
+          sudo apt install lcov -y
+
+      - name: Install common dependencies -- clang
+        if: ${{ matrix.os-version == 'ubuntu-latest' && matrix.compiler == 'clang' }}
+        run: |
+          sudo apt update
+          sudo apt install llvm -y
+
+      - name: Install compiler
+        id: install_cc
+        uses: rlalik/setup-cpp-compiler@v1.1
+        with:
+          compiler: ${{ matrix.compiler }}
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          submodules: recursive
+
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v1.9
+
+      - name: Coverage tests
+        shell: bash
+        env:
+          CC: ${{ steps.install_cc.outputs.cc }}
+          CXX: ${{ steps.install_cc.outputs.cxx }}
+        run: |
+          cmake \
+            -S example/code-coverage-target \
+            -B build_ccov \
+            -DCODE_COVERAGE=ON \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          cmake --build build_ccov --config ${{ matrix.build_type }}
+          cmake --build build_ccov --target help
+          cmake --build build_ccov --target ccov-main

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,61 @@
+# This is a basic workflow to help you get started with Actions
+name: Sanitizers
+
+# Controls when the action will run. Triggers the workflow on push
+on:
+  push:
+  pull_request:
+  release:
+    # tags:
+    # - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    name: "OS: ${{ matrix.os-version }}  CXX: ${{ matrix.compiler }}  SAN: ${{ matrix.sanitizer }}"
+    runs-on: ${{ matrix.os-version }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os-version: [ ubuntu-latest ]
+        compiler: [ gcc, clang ]
+        build_type: [ Debug ]
+        sanitizer: [ Address, Memory, Leak, Thread, Undefined ]
+
+    steps:
+      - name: Print env
+        run: |
+          echo github.event.action: ${{ github.event.action }}
+          echo github.event_name: ${{ github.event_name }}
+
+      - name: Install compiler
+        id: install_cc
+        uses: rlalik/setup-cpp-compiler@v1.1
+        with:
+          compiler: ${{ matrix.compiler }}
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        with:
+          submodules: recursive
+
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v1.9
+
+      - name: Test sanitizer
+        if: ${{ matrix.sanitizer != 'Memory' || matrix.sanitizer == 'Memory' && matrix.compiler == 'clang' }}
+        shell: bash
+        env:
+          CC: ${{ steps.install_cc.outputs.cc }}
+          CXX: ${{ steps.install_cc.outputs.cxx }}
+        run: |
+          cmake \
+            -S example/all \
+            -B build_sanitizer \
+            -DUSE_SANITIZER=${{ matrix.sanitizer }} \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          cmake --build build_sanitizer --config ${{ matrix.build_type }}

--- a/example/all/CMakeLists.txt
+++ b/example/all/CMakeLists.txt
@@ -14,6 +14,9 @@ include(dependency-graph)
 # Require C++11
 cxx_11()
 
+# required by ALL
+add_code_coverage_all_targets()
+
 # Tools
 file(GLOB_RECURSE FFILES *.[hc] *.[hc]pp)
 clang_format(format ${FFILES})


### PR DESCRIPTION
This set of workflows allows to test coverage and sanitizers. Helped to find regression (fixed in this commit) in the `example/all`.

For now runs on `ubuntu-latest` only, tests agains `gcc` and `clang`.