### PR TITLE
code-coverage.cmake: do not inline when determining code coverage

### DIFF
--- a/code-coverage.cmake
+++ b/code-coverage.cmake
@@ -259,7 +259,7 @@ function(target_code_coverage TARGET_NAME)
     elseif(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES
                                                 "GNU")
       target_compile_options(${TARGET_NAME} ${TARGET_VISIBILITY} -fprofile-arcs
-                             -ftest-coverage)
+                             -ftest-coverage -fno-elide-constructors -fno-default-inline)
       target_link_libraries(${TARGET_NAME} ${TARGET_LINK_VISIBILITY} gcov)
     endif()
 
@@ -501,7 +501,7 @@ function(add_code_coverage)
       add_link_options(-fprofile-instr-generate -fcoverage-mapping)
     elseif(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES
                                                 "GNU")
-      add_compile_options(-fprofile-arcs -ftest-coverage)
+      add_compile_options(-fprofile-arcs -ftest-coverage -fno-elide-constructors -fno-default-inline)
       link_libraries(gcov)
     endif()
   endif()


### PR DESCRIPTION
This fixes annoying false positives on GNU 11.3 on ubuntu-latest.

Before:
![Screenshot 2023-01-07 at 19 56 03](https://user-images.githubusercontent.com/27208977/211166297-aaf2c88f-b39f-4e69-bd91-79a096af08d0.png)

After:
![Screenshot 2023-01-07 at 19 57 18](https://user-images.githubusercontent.com/27208977/211166342-579864e2-e7db-471d-b5b8-3ec2b2b7cb56.png)
