### PR TITLE
Fix code coverage script on macOS by making it use xcrun's llvm-cov

### DIFF
--- a/code-coverage.cmake
+++ b/code-coverage.cmake
@@ -84,6 +84,13 @@ find_program(LLVM_COV_PATH llvm-cov)
 find_program(LLVM_PROFDATA_PATH llvm-profdata)
 find_program(LCOV_PATH lcov)
 find_program(GENHTML_PATH genhtml)
+
+# Check if `xcrun` is present and if so use `xcrun llvm-cov` instead.
+find_program(XCRUN_PATH xcrun)
+if(XCRUN_PATH)
+    set(LLVM_COV_PATH "xcrun;llvm-cov")
+endif()
+
 # Hide behind the 'advanced' mode flag for GUI/ccmake
 mark_as_advanced(FORCE LLVM_COV_PATH LLVM_PROFDATA_PATH LCOV_PATH GENHTML_PATH)
 


### PR DESCRIPTION
### Rationale

I was able to get the script `code-coverage.cmake` working inside a Ubuntu Docker container and on a Windows machine, but it would not work on my Mac because `llvm-cov` is not available in the PATH. Instead, `llvm-cov` has to be accessed via Xcode's `xcrun` tool, e.g. `xcrun llvm-cov`.

### Changes

This PR changes `code-coverage.cmake` so that it first checks to see if `xcrun` is present on the current system. If it is, then it changes `LLVM_COV_PATH` to be `xcrun;llvm-cov`. This change makes the script work on macOS.